### PR TITLE
fixed: internal "Cannot read property 'toJSON' of undefined" while handling network errors

### DIFF
--- a/platforms/facebook.js
+++ b/platforms/facebook.js
@@ -72,7 +72,7 @@ module.exports = function(token, userConfig) {
 					err = new Error('Failed to log incoming message');
 
 					if (callback)
-						callback(err);
+						return callback(err);
 					else
 						return err;
 				}
@@ -80,7 +80,7 @@ module.exports = function(token, userConfig) {
 				err = log.checkResponse(resp, 'Successfully logged incoming message.', 'Failed to log incoming message.');
 
 				if (callback)
-					callback(err);
+					return callback(err);
 				else
 					return err;
 			});


### PR DESCRIPTION
If botanalytics got network error

```
[Botanalytics] Error: Failed to log outgoing message. { Error: Client network socket disconnected before secure TLS connection was established
    at TLSSocket.onConnectEnd (_tls_wrap.js:1092:19)
    at Object.onceWrapper (events.js:286:20)
    at TLSSocket.emit (events.js:203:15)
    at endReadableNT (_stream_readable.js:1129:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
  code: 'ECONNRESET',
  path: null,
  host: 'd780852b95a4.ngrok.io',
  port: 443,
  localAddress: undefined }

```

then it throws an internal error:

```
\node_modules\botanalytics\util.js:25
		    const response = resp.toJSON();
		                          ^

TypeError: Cannot read property 'toJSON' of undefined
    at Object.checkResponse (\node_modules\botanalytics\util.js:25:29)
    at Request.request [as _callback] (\node_modules\botanalytics\platforms\facebook.js:143:15)

```

So my chatbot application exited.